### PR TITLE
Refine BR table foreign key handling with is_main flag

### DIFF
--- a/configs/meta_egg.dtd
+++ b/configs/meta_egg.dtd
@@ -138,7 +138,9 @@ table: 外链的目标数据库表
 counter: 计数对应的表字段名
 ri_raw: 倒排索引key的原始字段名
 auto_remove: 当链接的目标record被删除时, 是否自动删除当前record，仅对RL表有效
-is_main: 对于RL表，标识此外键是否指向主表 (true|false)
+is_main: 标识此外键的重要性 (true|false)
+    - 对于RL表：标识此外键是否指向主表
+    - 对于BR表：标识此外键是否为核心关系外键（区别于辅助外键如创建者、更新者等）
 -->
 <!ELEMENT foreign_key EMPTY>
 <!ATTLIST foreign_key

--- a/internal/domain/project_generator/template/manifest_dtd.go
+++ b/internal/domain/project_generator/template/manifest_dtd.go
@@ -140,7 +140,9 @@ table: 外链的目标数据库表
 counter: 计数对应的表字段名
 ri_raw: 倒排索引key的原始字段名
 auto_remove: 当链接的目标record被删除时, 是否自动删除当前record，仅对RL表有效
-is_main: 对于RL表，标识此外键是否指向主表 (true|false)
+is_main: 标识此外键的重要性 (true|false)
+    - 对于RL表：标识此外键是否指向主表
+    - 对于BR表：标识此外键是否为核心关系外键（区别于辅助外键如创建者、更新者等）
 -->
 <!ELEMENT foreign_key EMPTY>
 <!ATTLIST foreign_key


### PR DESCRIPTION
Updates clarify that the is_main attribute marks core foreign keys for BR tables, distinguishing them from auxiliary keys. Validation and identification logic now require exactly two is_main=true foreign keys pointing to distinct DATA tables, aligning with this refined model. This enhances accuracy in representing BR table relationships and enforces stricter schema correctness.